### PR TITLE
Change cert-manager issuer to avoid unneded emails

### DIFF
--- a/katalog/tests/harbor/config/kustomization.yaml
+++ b/katalog/tests/harbor/config/kustomization.yaml
@@ -1,3 +1,17 @@
 bases:
   - ./vendor/katalog/ingress/cert-manager
   - ./vendor/katalog/ingress/nginx
+
+patchesJson6902:
+- target:
+    group: cert-manager.io
+    version: v1alpha2
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  path: patches/issuer.yml
+- target:
+    group: cert-manager.io
+    version: v1alpha2
+    kind: ClusterIssuer
+    name: letsencrypt-staging
+  path: patches/issuer.yml

--- a/katalog/tests/harbor/config/patches/issuer.yml
+++ b/katalog/tests/harbor/config/patches/issuer.yml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/acme/email
+  value: test@example.com


### PR DESCRIPTION
Hi team!

I've changed the default email used to requests LE TLS certificates. This way we are not going to be notified when these certificates expires.

Only affects to e2e tests.

Thanks!