### PR TITLE
Upgrade harbor 2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ specific dependencies, please visit the single package's documentation:
 | v1.0.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | v1.0.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | v1.1.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.1.1                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains all components necessary to deploy a container registry
 The following packages are included in the Fury Kubernetes Registry Katalog.
 
 - [harbor](katalog/harbor): Harbor is an open-source container image registry that secures images with role-based
-access control, scans images for vulnerabilities, and signs images as trusted. Version: **2.1.2**
+access control, scans images for vulnerabilities, and signs images as trusted. Version: **2.1.3**
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains all components necessary to deploy a container registry
 The following packages are included in the Fury Kubernetes Registry Katalog.
 
 - [harbor](katalog/harbor): Harbor is an open-source container image registry that secures images with role-based
-access control, scans images for vulnerabilities, and signs images as trusted. Version: **2.1.0**
+access control, scans images for vulnerabilities, and signs images as trusted. Version: **2.1.2**
 
 ## Requirements
 

--- a/docs/releases/v1.1.1.md
+++ b/docs/releases/v1.1.1.md
@@ -1,11 +1,20 @@
 # Registry Module version 1.1.1
 
-FIX [CVE-2020-29662](https://github.com/goharbor/harbor/security/advisories/GHSA-38r5-34mr-mvm7): Catalog's registry v2
-api exposed on unauthenticated path
+This update contains a critical security patch. It solves the
+[CVE-2020-29662](https://github.com/goharbor/harbor/security/advisories/GHSA-38r5-34mr-mvm7). The Catalog's registry v2
+API is exposed on the unauthenticated path. We recommend updating the module as soon as possible.
 
 ## Changelog
 
-- Update Harbor from version `v2.1.1` to `v2.1.2`
+- Update Harbor from version `v2.1.1` to `v2.1.2`.
 
 ## Upgrade path
 
+To upgrade this module from `v1.1.0` to `v1.1.1`, you need to download this new version, then apply the
+`kustomize` project. No further action is required.
+
+```bash
+$ kustomize build katalog/harbor/distributions/full-harbor-with-trivy | kubectl apply -f -
+# Or
+$ kustomize build katalog/harbor/distributions/full-harbor | kubectl apply -f -
+```

--- a/docs/releases/v1.1.1.md
+++ b/docs/releases/v1.1.1.md
@@ -6,7 +6,7 @@ API is exposed on the unauthenticated path. We recommend updating the module as 
 
 ## Changelog
 
-- Update Harbor from version `v2.1.1` to `v2.1.2`.
+- Update Harbor from version `v2.1.1` to `v2.1.3`.
 
 ## Upgrade path
 

--- a/docs/releases/v1.1.1.md
+++ b/docs/releases/v1.1.1.md
@@ -1,0 +1,11 @@
+# Registry Module version 1.1.1
+
+FIX [CVE-2020-29662](https://github.com/goharbor/harbor/security/advisories/GHSA-38r5-34mr-mvm7): Catalog's registry v2
+api exposed on unauthenticated path
+
+## Changelog
+
+- Update Harbor from version `v2.1.1` to `v2.1.2`
+
+## Upgrade path
+

--- a/katalog/harbor/README.md
+++ b/katalog/harbor/README.md
@@ -12,19 +12,19 @@
 ## Image repository and tag
 
 * Harbor images from [dockerhub](https://hub.docker.com/u/goharbor):
-  * goharbor/chartmuseum-photon:v2.1.1
-  * goharbor/clair-photon:v2.1.1
-  * goharbor/clair-adapter-photon:v2.1.1
-  * goharbor/trivy-adapter-photon:v2.1.1
-  * goharbor/harbor-core:v2.1.1
-  * goharbor/harbor-db:v2.1.1
-  * goharbor/harbor-jobservice:v2.1.1
-  * goharbor/notary-server-photon:v2.1.1
-  * goharbor/notary-signer-photon:v2.1.1
-  * goharbor/harbor-portal:v2.1.1
-  * goharbor/redis-photon:v2.1.1
-  * goharbor/registry-photon:v2.1.1
-  * goharbor/harbor-registryctl:v2.1.1
+  * goharbor/chartmuseum-photon:v2.1.2
+  * goharbor/clair-photon:v2.1.2
+  * goharbor/clair-adapter-photon:v2.1.2
+  * goharbor/trivy-adapter-photon:v2.1.2
+  * goharbor/harbor-core:v2.1.2
+  * goharbor/harbor-db:v2.1.2
+  * goharbor/harbor-jobservice:v2.1.2
+  * goharbor/notary-server-photon:v2.1.2
+  * goharbor/notary-signer-photon:v2.1.2
+  * goharbor/harbor-portal:v2.1.2
+  * goharbor/redis-photon:v2.1.2
+  * goharbor/registry-photon:v2.1.2
+  * goharbor/harbor-registryctl:v2.1.2
 * Harbor repository: [https://github.com/goharbor/harbor](https://github.com/goharbor/harbor)
 
 ## Distributions

--- a/katalog/harbor/README.md
+++ b/katalog/harbor/README.md
@@ -12,19 +12,19 @@
 ## Image repository and tag
 
 * Harbor images from [dockerhub](https://hub.docker.com/u/goharbor):
-  * goharbor/chartmuseum-photon:v2.1.2
-  * goharbor/clair-photon:v2.1.2
-  * goharbor/clair-adapter-photon:v2.1.2
-  * goharbor/trivy-adapter-photon:v2.1.2
-  * goharbor/harbor-core:v2.1.2
-  * goharbor/harbor-db:v2.1.2
-  * goharbor/harbor-jobservice:v2.1.2
-  * goharbor/notary-server-photon:v2.1.2
-  * goharbor/notary-signer-photon:v2.1.2
-  * goharbor/harbor-portal:v2.1.2
-  * goharbor/redis-photon:v2.1.2
-  * goharbor/registry-photon:v2.1.2
-  * goharbor/harbor-registryctl:v2.1.2
+  * goharbor/chartmuseum-photon:v2.1.3
+  * goharbor/clair-photon:v2.1.3
+  * goharbor/clair-adapter-photon:v2.1.3
+  * goharbor/trivy-adapter-photon:v2.1.3
+  * goharbor/harbor-core:v2.1.3
+  * goharbor/harbor-db:v2.1.3
+  * goharbor/harbor-jobservice:v2.1.3
+  * goharbor/notary-server-photon:v2.1.3
+  * goharbor/notary-signer-photon:v2.1.3
+  * goharbor/harbor-portal:v2.1.3
+  * goharbor/redis-photon:v2.1.3
+  * goharbor/registry-photon:v2.1.3
+  * goharbor/harbor-registryctl:v2.1.3
 * Harbor repository: [https://github.com/goharbor/harbor](https://github.com/goharbor/harbor)
 
 ## Distributions

--- a/katalog/harbor/chartmuseum/kustomization.yaml
+++ b/katalog/harbor/chartmuseum/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/chartmuseum-photon
-    newTag: v2.1.2
+    newTag: v2.1.3
 
 resources:
   - pvc.yml

--- a/katalog/harbor/chartmuseum/kustomization.yaml
+++ b/katalog/harbor/chartmuseum/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/chartmuseum-photon
-    newTag: v2.1.1
+    newTag: v2.1.2
 
 resources:
   - pvc.yml

--- a/katalog/harbor/clair/kustomization.yaml
+++ b/katalog/harbor/clair/kustomization.yaml
@@ -12,9 +12,9 @@ resources:
 
 images:
   - name: goharbor/clair-photon
-    newTag: v2.1.2
+    newTag: v2.1.3
   - name: goharbor/clair-adapter-photon
-    newTag: v2.1.2
+    newTag: v2.1.3
 
 configMapGenerator:
   - name: clair

--- a/katalog/harbor/clair/kustomization.yaml
+++ b/katalog/harbor/clair/kustomization.yaml
@@ -12,9 +12,9 @@ resources:
 
 images:
   - name: goharbor/clair-photon
-    newTag: v2.1.1
+    newTag: v2.1.2
   - name: goharbor/clair-adapter-photon
-    newTag: v2.1.1
+    newTag: v2.1.2
 
 configMapGenerator:
   - name: clair

--- a/katalog/harbor/core/kustomization.yaml
+++ b/katalog/harbor/core/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: goharbor/harbor-core
-    newTag: v2.1.1
+    newTag: v2.1.2
 
 configMapGenerator:
   - name: core

--- a/katalog/harbor/core/kustomization.yaml
+++ b/katalog/harbor/core/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: goharbor/harbor-core
-    newTag: v2.1.2
+    newTag: v2.1.3
 
 configMapGenerator:
   - name: core

--- a/katalog/harbor/database/kustomization.yaml
+++ b/katalog/harbor/database/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/harbor-db
-    newTag: v2.1.2
+    newTag: v2.1.3
 
 resources:
   - sts.yml

--- a/katalog/harbor/database/kustomization.yaml
+++ b/katalog/harbor/database/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/harbor-db
-    newTag: v2.1.1
+    newTag: v2.1.2
 
 resources:
   - sts.yml

--- a/katalog/harbor/jobservice/kustomization.yaml
+++ b/katalog/harbor/jobservice/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 
 images:
   - name: goharbor/harbor-jobservice
-    newTag: v2.1.2
+    newTag: v2.1.3
 
 configMapGenerator:
   - name: jobservice

--- a/katalog/harbor/jobservice/kustomization.yaml
+++ b/katalog/harbor/jobservice/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 
 images:
   - name: goharbor/harbor-jobservice
-    newTag: v2.1.1
+    newTag: v2.1.2
 
 configMapGenerator:
   - name: jobservice

--- a/katalog/harbor/notary/kustomization.yaml
+++ b/katalog/harbor/notary/kustomization.yaml
@@ -8,9 +8,9 @@ kind: Kustomization
 
 images:
   - name: goharbor/notary-server-photon
-    newTag: v2.1.2
+    newTag: v2.1.3
   - name: goharbor/notary-signer-photon
-    newTag: v2.1.2
+    newTag: v2.1.3
 
 resources:
   - pki.yml

--- a/katalog/harbor/notary/kustomization.yaml
+++ b/katalog/harbor/notary/kustomization.yaml
@@ -8,9 +8,9 @@ kind: Kustomization
 
 images:
   - name: goharbor/notary-server-photon
-    newTag: v2.1.1
+    newTag: v2.1.2
   - name: goharbor/notary-signer-photon
-    newTag: v2.1.1
+    newTag: v2.1.2
 
 resources:
   - pki.yml

--- a/katalog/harbor/portal/kustomization.yaml
+++ b/katalog/harbor/portal/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/harbor-portal
-    newTag: v2.1.2
+    newTag: v2.1.3
 
 resources:
   - deploy.yml

--- a/katalog/harbor/portal/kustomization.yaml
+++ b/katalog/harbor/portal/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/harbor-portal
-    newTag: v2.1.1
+    newTag: v2.1.2
 
 resources:
   - deploy.yml

--- a/katalog/harbor/redis/kustomization.yaml
+++ b/katalog/harbor/redis/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/redis-photon
-    newTag: v2.1.1
+    newTag: v2.1.2
 
 resources:
   - sts.yml

--- a/katalog/harbor/redis/kustomization.yaml
+++ b/katalog/harbor/redis/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/redis-photon
-    newTag: v2.1.2
+    newTag: v2.1.3
 
 resources:
   - sts.yml

--- a/katalog/harbor/registry/kustomization.yaml
+++ b/katalog/harbor/registry/kustomization.yaml
@@ -13,9 +13,9 @@ resources:
 
 images:
   - name: goharbor/registry-photon
-    newTag: v2.1.2
+    newTag: v2.1.3
   - name: goharbor/harbor-registryctl
-    newTag: v2.1.2
+    newTag: v2.1.3
 
 configMapGenerator:
   - name: registry

--- a/katalog/harbor/registry/kustomization.yaml
+++ b/katalog/harbor/registry/kustomization.yaml
@@ -13,9 +13,9 @@ resources:
 
 images:
   - name: goharbor/registry-photon
-    newTag: v2.1.1
+    newTag: v2.1.2
   - name: goharbor/harbor-registryctl
-    newTag: v2.1.1
+    newTag: v2.1.2
 
 configMapGenerator:
   - name: registry

--- a/katalog/harbor/trivy/kustomization.yaml
+++ b/katalog/harbor/trivy/kustomization.yaml
@@ -16,7 +16,7 @@ commonLabels:
 
 images:
   - name: goharbor/trivy-adapter-photon
-    newTag: v2.1.2
+    newTag: v2.1.3
 
 configMapGenerator:
   - name: trivy

--- a/katalog/harbor/trivy/kustomization.yaml
+++ b/katalog/harbor/trivy/kustomization.yaml
@@ -16,7 +16,7 @@ commonLabels:
 
 images:
   - name: goharbor/trivy-adapter-photon
-    newTag: v2.1.1
+    newTag: v2.1.2
 
 configMapGenerator:
   - name: trivy

--- a/katalog/tests/harbor/chartmuseum.sh
+++ b/katalog/tests/harbor/chartmuseum.sh
@@ -10,7 +10,7 @@ load "./../lib/helper"
 @test "[CHARTS] Setup" {
     info
     setup(){
-        helm init --client-only
+        helm init --client-only --stable-repo-url https://charts.helm.sh/stable
         helm plugin install https://github.com/chartmuseum/helm-push
         helm fetch stable/nginx-ingress --version 1.36.2
         helm repo add --username=admin --password=Harbor12345 harbor-test https://harbor."${EXTERNAL_DNS}"/chartrepo/library

--- a/katalog/tests/harbor/config/Furyfile.yml
+++ b/katalog/tests/harbor/config/Furyfile.yml
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 versions:
-  ingress: v1.8.1
+  ingress: v1.8.2
 
 bases:
   - name: ingress/cert-manager

--- a/katalog/tests/harbor/setup.sh
+++ b/katalog/tests/harbor/setup.sh
@@ -10,9 +10,9 @@ load "./../lib/helper"
 @test "[SETUP] pre-requirements - CRDs" {
     info
     crds(){
-        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.2/katalog/prometheus-operator/crd-prometheus.yml
-        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.2/katalog/prometheus-operator/crd-servicemonitor.yml
-        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.2/katalog/prometheus-operator/crd-rule.yml
+        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.3/katalog/prometheus-operator/crd-prometheus.yml
+        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.3/katalog/prometheus-operator/crd-servicemonitor.yml
+        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.3/katalog/prometheus-operator/crd-rule.yml
     }
     run crds
     [ "$status" -eq 0 ]


### PR DESCRIPTION
This update contains a critical security patch. It solves the CVE-2020-29662. The Catalog's registry v2 API is exposed on the unauthenticated path. We recommend updating the module as soon as possible.

I've tested the upgrade procedure manually,
Automated tests happen on the pipeline: http://ci.sighup.io/sighupio/fury-kubernetes-registry/116/5/7

Thanks!