### PR TITLE
Correct registry url used by jobservice for garbage collection

### DIFF
--- a/katalog/harbor/jobservice/kustomization.yaml
+++ b/katalog/harbor/jobservice/kustomization.yaml
@@ -20,7 +20,7 @@ configMapGenerator:
       - config.yml=config/config.yml
     literals:
       - CORE_URL=http://core
-      - REGISTRY_CONTROLLER_URL=http://registry
+      - REGISTRY_CONTROLLER_URL=http://registry:8080
       - LOG_LEVEL=info
       - HTTP_PROXY=
       - HTTPS_PROXY=


### PR DESCRIPTION
Hi,

Currently environment variable `REGISTRY_CONTROLLER_URL` used by **jobservice** is set wrong, when triggered to do Garbage Collection, **jobservice** fails because it tries to connect to `http://registry:80` but **registry** listens on port `8080`. 

This PR fixes environment variabile in order to point to correct url.

Thanks 🙏 