### PR TITLE
Update to latest 2.1.X Harbor Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains all components necessary to deploy a container registry
 The following packages are included in the Fury Kubernetes Registry Katalog.
 
 - [harbor](katalog/harbor): Harbor is an open-source container image registry that secures images with role-based
-access control, scans images for vulnerabilities, and signs images as trusted. Version: **2.1.3**
+access control, scans images for vulnerabilities, and signs images as trusted. Version: **2.1.5**
 
 ## Requirements
 

--- a/docs/releases/v1.1.2.md
+++ b/docs/releases/v1.1.2.md
@@ -1,0 +1,18 @@
+# Registry Module version 1.1.2
+
+
+## Changelog
+
+- Update Harbor from version `v2.1.3` to `v2.1.5`.
+- Bugfix at the Garbage Collector. Thanks to @beratio PR #9.
+
+## Upgrade path
+
+To upgrade this module from `v1.1.1` to `v1.1.2`, you need to download this new version, then apply the
+`kustomize` project. No further action is required.
+
+```bash
+$ kustomize build katalog/harbor/distributions/full-harbor-with-trivy | kubectl apply -f -
+# Or
+$ kustomize build katalog/harbor/distributions/full-harbor | kubectl apply -f -
+```

--- a/docs/releases/v1.1.2.md
+++ b/docs/releases/v1.1.2.md
@@ -5,6 +5,7 @@
 
 - Update Harbor from version `v2.1.3` to `v2.1.5`.
 - Bugfix at the Garbage Collector. Thanks to @beratio PR #9.
+- All container images comes from [registry.sighup.io] by default *(to avoid dockerhub rate limit)*.
 
 ## Upgrade path
 

--- a/docs/releases/v1.1.2.md
+++ b/docs/releases/v1.1.2.md
@@ -5,7 +5,7 @@
 
 - Update Harbor from version `v2.1.3` to `v2.1.5`.
 - Bugfix at the Garbage Collector. Thanks to @beratio PR #9.
-- All container images comes from [registry.sighup.io] by default *(to avoid dockerhub rate limit)*.
+- All container images come from [registry.sighup.io] by default *(to avoid dockerhub rate limit)*.
 
 ## Upgrade path
 

--- a/katalog/harbor/README.md
+++ b/katalog/harbor/README.md
@@ -12,19 +12,19 @@
 ## Image repository and tag
 
 * Harbor images from [dockerhub](https://hub.docker.com/u/goharbor):
-  * goharbor/chartmuseum-photon:v2.1.3
-  * goharbor/clair-photon:v2.1.3
-  * goharbor/clair-adapter-photon:v2.1.3
-  * goharbor/trivy-adapter-photon:v2.1.3
-  * goharbor/harbor-core:v2.1.3
-  * goharbor/harbor-db:v2.1.3
-  * goharbor/harbor-jobservice:v2.1.3
-  * goharbor/notary-server-photon:v2.1.3
-  * goharbor/notary-signer-photon:v2.1.3
-  * goharbor/harbor-portal:v2.1.3
-  * goharbor/redis-photon:v2.1.3
-  * goharbor/registry-photon:v2.1.3
-  * goharbor/harbor-registryctl:v2.1.3
+  * goharbor/chartmuseum-photon:v2.1.5
+  * goharbor/clair-photon:v2.1.5
+  * goharbor/clair-adapter-photon:v2.1.5
+  * goharbor/trivy-adapter-photon:v2.1.5
+  * goharbor/harbor-core:v2.1.5
+  * goharbor/harbor-db:v2.1.5
+  * goharbor/harbor-jobservice:v2.1.5
+  * goharbor/notary-server-photon:v2.1.5
+  * goharbor/notary-signer-photon:v2.1.5
+  * goharbor/harbor-portal:v2.1.5
+  * goharbor/redis-photon:v2.1.5
+  * goharbor/registry-photon:v2.1.5
+  * goharbor/harbor-registryctl:v2.1.5
 * Harbor repository: [https://github.com/goharbor/harbor](https://github.com/goharbor/harbor)
 
 ## Distributions

--- a/katalog/harbor/chartmuseum/kustomization.yaml
+++ b/katalog/harbor/chartmuseum/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/chartmuseum-photon
-    newTag: v2.1.3
+    newTag: v2.1.5
 
 resources:
   - pvc.yml

--- a/katalog/harbor/chartmuseum/kustomization.yaml
+++ b/katalog/harbor/chartmuseum/kustomization.yaml
@@ -8,6 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/chartmuseum-photon
+    newName: registry.sighup.io/fury/goharbor/chartmuseum-photon
     newTag: v2.1.5
 
 resources:

--- a/katalog/harbor/clair/kustomization.yaml
+++ b/katalog/harbor/clair/kustomization.yaml
@@ -12,8 +12,10 @@ resources:
 
 images:
   - name: goharbor/clair-photon
+    newName: registry.sighup.io/fury/goharbor/clair-photon
     newTag: v2.1.5
   - name: goharbor/clair-adapter-photon
+    newName: registry.sighup.io/fury/goharbor/clair-adapter-photon
     newTag: v2.1.5
 
 configMapGenerator:

--- a/katalog/harbor/clair/kustomization.yaml
+++ b/katalog/harbor/clair/kustomization.yaml
@@ -12,9 +12,9 @@ resources:
 
 images:
   - name: goharbor/clair-photon
-    newTag: v2.1.3
+    newTag: v2.1.5
   - name: goharbor/clair-adapter-photon
-    newTag: v2.1.3
+    newTag: v2.1.5
 
 configMapGenerator:
   - name: clair

--- a/katalog/harbor/core/kustomization.yaml
+++ b/katalog/harbor/core/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 
 images:
   - name: goharbor/harbor-core
-    newTag: v2.1.3
+    newTag: v2.1.5
 
 configMapGenerator:
   - name: core

--- a/katalog/harbor/core/kustomization.yaml
+++ b/katalog/harbor/core/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 
 images:
   - name: goharbor/harbor-core
+    newName: registry.sighup.io/fury/goharbor/harbor-core
     newTag: v2.1.5
 
 configMapGenerator:

--- a/katalog/harbor/database/kustomization.yaml
+++ b/katalog/harbor/database/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/harbor-db
-    newTag: v2.1.3
+    newTag: v2.1.5
 
 resources:
   - sts.yml

--- a/katalog/harbor/database/kustomization.yaml
+++ b/katalog/harbor/database/kustomization.yaml
@@ -8,7 +8,11 @@ kind: Kustomization
 
 images:
   - name: goharbor/harbor-db
+    newName: registry.sighup.io/fury/goharbor/harbor-db
     newTag: v2.1.5
+  - name: busybox
+    newName: registry.sighup.io/fury/busybox
+    newTag: latest
 
 resources:
   - sts.yml

--- a/katalog/harbor/database/sts.yml
+++ b/katalog/harbor/database/sts.yml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
         - name: change-permission-of-directory
-          image: busybox:latest
+          image: busybox
           imagePullPolicy: Always
           command: ["/bin/sh"]
           args: ["-c", "chown -R 999:999 /var/lib/postgresql/data"]

--- a/katalog/harbor/jobservice/kustomization.yaml
+++ b/katalog/harbor/jobservice/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 
 images:
   - name: goharbor/harbor-jobservice
-    newTag: v2.1.3
+    newTag: v2.1.5
 
 configMapGenerator:
   - name: jobservice

--- a/katalog/harbor/jobservice/kustomization.yaml
+++ b/katalog/harbor/jobservice/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 
 images:
   - name: goharbor/harbor-jobservice
+    newName: registry.sighup.io/fury/goharbor/harbor-jobservice
     newTag: v2.1.5
 
 configMapGenerator:

--- a/katalog/harbor/notary/kustomization.yaml
+++ b/katalog/harbor/notary/kustomization.yaml
@@ -8,8 +8,10 @@ kind: Kustomization
 
 images:
   - name: goharbor/notary-server-photon
+    newName: registry.sighup.io/fury/goharbor/notary-server-photon
     newTag: v2.1.5
   - name: goharbor/notary-signer-photon
+    newName: registry.sighup.io/fury/goharbor/notary-signer-photon
     newTag: v2.1.5
 
 resources:

--- a/katalog/harbor/notary/kustomization.yaml
+++ b/katalog/harbor/notary/kustomization.yaml
@@ -8,9 +8,9 @@ kind: Kustomization
 
 images:
   - name: goharbor/notary-server-photon
-    newTag: v2.1.3
+    newTag: v2.1.5
   - name: goharbor/notary-signer-photon
-    newTag: v2.1.3
+    newTag: v2.1.5
 
 resources:
   - pki.yml

--- a/katalog/harbor/portal/kustomization.yaml
+++ b/katalog/harbor/portal/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/harbor-portal
-    newTag: v2.1.3
+    newTag: v2.1.5
 
 resources:
   - deploy.yml

--- a/katalog/harbor/portal/kustomization.yaml
+++ b/katalog/harbor/portal/kustomization.yaml
@@ -8,6 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/harbor-portal
+    newName: registry.sighup.io/fury/goharbor/harbor-portal
     newTag: v2.1.5
 
 resources:

--- a/katalog/harbor/redis/kustomization.yaml
+++ b/katalog/harbor/redis/kustomization.yaml
@@ -8,6 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/redis-photon
+    newName: registry.sighup.io/fury/goharbor/redis-photon
     newTag: v2.1.5
 
 resources:

--- a/katalog/harbor/redis/kustomization.yaml
+++ b/katalog/harbor/redis/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 
 images:
   - name: goharbor/redis-photon
-    newTag: v2.1.3
+    newTag: v2.1.5
 
 resources:
   - sts.yml

--- a/katalog/harbor/registry/kustomization.yaml
+++ b/katalog/harbor/registry/kustomization.yaml
@@ -13,8 +13,10 @@ resources:
 
 images:
   - name: goharbor/registry-photon
+    newName: registry.sighup.io/fury/goharbor/registry-photon
     newTag: v2.1.5
   - name: goharbor/harbor-registryctl
+    newName: registry.sighup.io/fury/goharbor/harbor-registryctl
     newTag: v2.1.5
 
 configMapGenerator:

--- a/katalog/harbor/registry/kustomization.yaml
+++ b/katalog/harbor/registry/kustomization.yaml
@@ -13,9 +13,9 @@ resources:
 
 images:
   - name: goharbor/registry-photon
-    newTag: v2.1.3
+    newTag: v2.1.5
   - name: goharbor/harbor-registryctl
-    newTag: v2.1.3
+    newTag: v2.1.5
 
 configMapGenerator:
   - name: registry

--- a/katalog/harbor/trivy/kustomization.yaml
+++ b/katalog/harbor/trivy/kustomization.yaml
@@ -16,7 +16,7 @@ commonLabels:
 
 images:
   - name: goharbor/trivy-adapter-photon
-    newTag: v2.1.3
+    newTag: v2.1.5
 
 configMapGenerator:
   - name: trivy

--- a/katalog/harbor/trivy/kustomization.yaml
+++ b/katalog/harbor/trivy/kustomization.yaml
@@ -16,6 +16,7 @@ commonLabels:
 
 images:
   - name: goharbor/trivy-adapter-photon
+    newName: registry.sighup.io/fury/goharbor/trivy-adapter-photon
     newTag: v2.1.5
 
 configMapGenerator:

--- a/katalog/tests/harbor/setup.sh
+++ b/katalog/tests/harbor/setup.sh
@@ -10,9 +10,9 @@ load "./../lib/helper"
 @test "[SETUP] pre-requirements - CRDs" {
     info
     crds(){
-        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.3/katalog/prometheus-operator/crd-prometheus.yml
-        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.3/katalog/prometheus-operator/crd-servicemonitor.yml
-        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.3/katalog/prometheus-operator/crd-rule.yml
+        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.12.0/katalog/prometheus-operator/crd-prometheus.yml
+        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.12.0/katalog/prometheus-operator/crd-servicemonitor.yml
+        kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.12.0/katalog/prometheus-operator/crd-rule.yml
     }
     run crds
     [ "$status" -eq 0 ]


### PR DESCRIPTION
# Registry Module version 1.1.2


## Changelog

- Update Harbor from version `v2.1.3` to `v2.1.5`.
- Bugfix at the Garbage Collector. Thanks to @beratio PR #9.
- All container images come from [registry.sighup.io] by default *(to avoid dockerhub rate limit)*.

## Upgrade path

To upgrade this module from `v1.1.1` to `v1.1.2`, you need to download this new version, then apply the
`kustomize` project. No further action is required.

```bash
$ kustomize build katalog/harbor/distributions/full-harbor-with-trivy | kubectl apply -f -
# Or
$ kustomize build katalog/harbor/distributions/full-harbor | kubectl apply -f -
```
