### PR TITLE
Upgrade harbor to 2.2.2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ name: license
 
 steps:
   - name: check
-    image: docker.io/library/golang:1.14.3
+    image: docker.io/library/golang:1.16
     pull: always
     commands:
       - go get -u github.com/google/addlicense
@@ -31,7 +31,7 @@ steps:
       - clone
 
   - name: render
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.8_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.19_3.8.7_2.4.1
     pull: always
     depends_on:
       - clone
@@ -39,384 +39,13 @@ steps:
       - kustomize build katalog/harbor/distributions/full-harbor > distribution.yml
 
   - name: deprek8ion
-    image: eu.gcr.io/swade1987/deprek8ion:1.1.31
+    image: eu.gcr.io/swade1987/deprek8ion:1.1.34
     pull: always
     depends_on:
       - render
     commands:
       - /conftest test -p /policies distribution.yml
----
-kind: pipeline
-name: e2e-kubernetes-1.16
 
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: custom-cluster-116
-      pipeline_id: cluster-116
-      local_kind_config_path: katalog/tests/harbor/config/kind-config
-      cluster_version: '1.16.9'
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: e2e-setup
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.16.15_3.3.0_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
-    environment:
-      DYNAMIC_DNS_SERVICE:
-        from_secret: dynamic_dns_service
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - export INSTANCE_IP=$(cat /shared/machine/ip)
-      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
-      - bats -t katalog/tests/harbor/setup.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: e2e-vulns
-    image: docker:dind
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    - name: dockersock
-      path: /var/run/docker.sock
-    environment:
-      DYNAMIC_DNS_SERVICE:
-        from_secret: dynamic_dns_service
-    depends_on: [ e2e-setup ]
-    commands:
-      - apk add curl jq git bash ca-certificates
-      - git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
-      - cd /tmp/bats-core
-      - git checkout v1.1.0
-      - ./install.sh /usr/local
-      - cd -
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - export INSTANCE_IP=$(cat /shared/machine/ip)
-      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
-      - bats -t katalog/tests/harbor/vulns.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: e2e-chartmuseum
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.16.15_3.3.0_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    environment:
-      DYNAMIC_DNS_SERVICE:
-        from_secret: dynamic_dns_service
-    depends_on: [ e2e-setup ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - export INSTANCE_IP=$(cat /shared/machine/ip)
-      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
-      - bats -t katalog/tests/harbor/chartmuseum.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: e2e-replication
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.16.15_3.3.0_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    environment:
-      DYNAMIC_DNS_SERVICE:
-        from_secret: dynamic_dns_service
-    depends_on: [ e2e-setup ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - export INSTANCE_IP=$(cat /shared/machine/ip)
-      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
-      - bats -t katalog/tests/harbor/replication.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: e2e-registry
-    image: docker:dind
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    - name: dockersock
-      path: /var/run/docker.sock
-    environment:
-      DYNAMIC_DNS_SERVICE:
-        from_secret: dynamic_dns_service
-    depends_on: [ e2e-setup ]
-    commands:
-      - apk add curl jq git bash ca-certificates
-      - git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
-      - cd /tmp/bats-core
-      - git checkout v1.1.0
-      - ./install.sh /usr/local
-      - cd -
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - export INSTANCE_IP=$(cat /shared/machine/ip)
-      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
-      - bats -t katalog/tests/harbor/registry.sh
-      - bats -t katalog/tests/harbor/registry-notary.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
-    pull: always
-    depends_on: [ e2e-vulns, e2e-chartmuseum, e2e-replication, e2e-registry ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-116
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-    when:
-      status:
-      - success
-      - failure
-
-volumes:
-- name: shared
-  temp: {}
-- name: dockersock
-  host:
-    path: /var/run/docker.sock
----
-kind: pipeline
-name: e2e-kubernetes-1.17
-
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: custom-cluster-117
-      pipeline_id: cluster-117
-      local_kind_config_path: katalog/tests/harbor/config/kind-config
-      cluster_version: '1.17.5'
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: e2e-setup
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.11_3.3.0_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
-    environment:
-      DYNAMIC_DNS_SERVICE:
-        from_secret: dynamic_dns_service
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-117
-      - export INSTANCE_IP=$(cat /shared/machine/ip)
-      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
-      - bats -t katalog/tests/harbor/setup.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: e2e-vulns
-    image: docker:dind
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    - name: dockersock
-      path: /var/run/docker.sock
-    environment:
-      DYNAMIC_DNS_SERVICE:
-        from_secret: dynamic_dns_service
-    depends_on: [ e2e-setup ]
-    commands:
-      - apk add curl jq git bash ca-certificates
-      - git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
-      - cd /tmp/bats-core
-      - git checkout v1.1.0
-      - ./install.sh /usr/local
-      - cd -
-      - export KUBECONFIG=/shared/kube/kubeconfig-117
-      - export INSTANCE_IP=$(cat /shared/machine/ip)
-      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
-      - bats -t katalog/tests/harbor/vulns.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: e2e-chartmuseum
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.11_3.3.0_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    environment:
-      DYNAMIC_DNS_SERVICE:
-        from_secret: dynamic_dns_service
-    depends_on: [ e2e-setup ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-117
-      - export INSTANCE_IP=$(cat /shared/machine/ip)
-      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
-      - bats -t katalog/tests/harbor/chartmuseum.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: e2e-replication
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.11_3.3.0_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    environment:
-      DYNAMIC_DNS_SERVICE:
-        from_secret: dynamic_dns_service
-    depends_on: [ e2e-setup ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-117
-      - export INSTANCE_IP=$(cat /shared/machine/ip)
-      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
-      - bats -t katalog/tests/harbor/replication.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: e2e-registry
-    image: docker:dind
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    - name: dockersock
-      path: /var/run/docker.sock
-    environment:
-      DYNAMIC_DNS_SERVICE:
-        from_secret: dynamic_dns_service
-    depends_on: [ e2e-setup ]
-    commands:
-      - apk add curl jq git bash ca-certificates
-      - git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
-      - cd /tmp/bats-core
-      - git checkout v1.1.0
-      - ./install.sh /usr/local
-      - cd -
-      - export KUBECONFIG=/shared/kube/kubeconfig-117
-      - export INSTANCE_IP=$(cat /shared/machine/ip)
-      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
-      - bats -t katalog/tests/harbor/registry.sh
-      - bats -t katalog/tests/harbor/registry-notary.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
-    pull: always
-    depends_on: [ e2e-vulns, e2e-chartmuseum, e2e-replication, e2e-registry ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-117
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-    when:
-      status:
-      - success
-      - failure
-
-volumes:
-- name: shared
-  temp: {}
-- name: dockersock
-  host:
-    path: /var/run/docker.sock
 ---
 kind: pipeline
 name: e2e-kubernetes-1.18
@@ -435,7 +64,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0-final-aws
     pull: always
     volumes:
     - name: shared
@@ -445,7 +74,7 @@ steps:
       action: custom-cluster-118
       pipeline_id: cluster-118
       local_kind_config_path: katalog/tests/harbor/config/kind-config
-      cluster_version: '1.18.8'
+      cluster_version: '1.18.19'
       instance_path: /shared
       aws_default_region:
         from_secret: aws_region
@@ -455,13 +84,17 @@ steps:
         from_secret: aws_secret_access_key
       terraform_tf_states_bucket_name:
         from_secret: terraform_tf_states_bucket_name
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
     when:
       ref:
         include:
           - refs/tags/**
 
   - name: e2e-setup
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.8_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.19_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -509,7 +142,7 @@ steps:
           - refs/tags/**
 
   - name: e2e-chartmuseum
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.8_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.19_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -529,7 +162,7 @@ steps:
           - refs/tags/**
 
   - name: e2e-replication
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.8_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.19_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -578,7 +211,7 @@ steps:
           - refs/tags/**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0-final-aws
     pull: always
     depends_on: [ e2e-vulns, e2e-chartmuseum, e2e-replication, e2e-registry ]
     settings:
@@ -592,6 +225,595 @@ steps:
         from_secret: aws_secret_access_key
       terraform_tf_states_bucket_name:
         from_secret: terraform_tf_states_bucket_name
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      status:
+      - success
+      - failure
+
+volumes:
+- name: shared
+  temp: {}
+- name: dockersock
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
+name: e2e-kubernetes-1.19
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0-final-aws
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: custom-cluster-119
+      pipeline_id: cluster-119
+      local_kind_config_path: katalog/tests/harbor/config/kind-config
+      cluster_version: '1.19.11'
+      instance_path: /shared
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-setup
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.19.11_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init ]
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-119
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/setup.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-vulns
+    image: docker:dind
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    - name: dockersock
+      path: /var/run/docker.sock
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - apk add curl jq git bash ca-certificates
+      - git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+      - cd /tmp/bats-core
+      - git checkout v1.1.0
+      - ./install.sh /usr/local
+      - cd -
+      - export KUBECONFIG=/shared/kube/kubeconfig-119
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/vulns.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-chartmuseum
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.19.11_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-119
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/chartmuseum.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-replication
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.19.11_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-119
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/replication.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-registry
+    image: docker:dind
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    - name: dockersock
+      path: /var/run/docker.sock
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - apk add curl jq git bash ca-certificates
+      - git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+      - cd /tmp/bats-core
+      - git checkout v1.1.0
+      - ./install.sh /usr/local
+      - cd -
+      - export KUBECONFIG=/shared/kube/kubeconfig-119
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/registry.sh
+      - bats -t katalog/tests/harbor/registry-notary.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0-final-aws
+    pull: always
+    depends_on: [ e2e-vulns, e2e-chartmuseum, e2e-replication, e2e-registry ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-119
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      status:
+      - success
+      - failure
+
+volumes:
+- name: shared
+  temp: {}
+- name: dockersock
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
+name: e2e-kubernetes-1.20
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0-final-aws
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: custom-cluster-120
+      pipeline_id: cluster-120
+      local_kind_config_path: katalog/tests/harbor/config/kind-config
+      cluster_version: '1.20.7'
+      instance_path: /shared
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-setup
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.20.7_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init ]
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/setup.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-vulns
+    image: docker:dind
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    - name: dockersock
+      path: /var/run/docker.sock
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - apk add curl jq git bash ca-certificates
+      - git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+      - cd /tmp/bats-core
+      - git checkout v1.1.0
+      - ./install.sh /usr/local
+      - cd -
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/vulns.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-chartmuseum
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.20.7_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/chartmuseum.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-replication
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.20.7_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/replication.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-registry
+    image: docker:dind
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    - name: dockersock
+      path: /var/run/docker.sock
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - apk add curl jq git bash ca-certificates
+      - git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+      - cd /tmp/bats-core
+      - git checkout v1.1.0
+      - ./install.sh /usr/local
+      - cd -
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/registry.sh
+      - bats -t katalog/tests/harbor/registry-notary.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0-final-aws
+    pull: always
+    depends_on: [ e2e-vulns, e2e-chartmuseum, e2e-replication, e2e-registry ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-120
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      status:
+      - success
+      - failure
+
+volumes:
+- name: shared
+  temp: {}
+- name: dockersock
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
+name: e2e-kubernetes-1.21
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0-final-aws
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: custom-cluster-121
+      pipeline_id: cluster-121
+      local_kind_config_path: katalog/tests/harbor/config/kind-config
+      cluster_version: '1.21.1'
+      instance_path: /shared
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-setup
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.21.1_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init ]
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-121
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/setup.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-vulns
+    image: docker:dind
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    - name: dockersock
+      path: /var/run/docker.sock
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - apk add curl jq git bash ca-certificates
+      - git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+      - cd /tmp/bats-core
+      - git checkout v1.1.0
+      - ./install.sh /usr/local
+      - cd -
+      - export KUBECONFIG=/shared/kube/kubeconfig-121
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/vulns.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-chartmuseum
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.21.1_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-121
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/chartmuseum.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-replication
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.21.1_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-121
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/replication.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: e2e-registry
+    image: docker:dind
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    - name: dockersock
+      path: /var/run/docker.sock
+    environment:
+      DYNAMIC_DNS_SERVICE:
+        from_secret: dynamic_dns_service
+    depends_on: [ e2e-setup ]
+    commands:
+      - apk add curl jq git bash ca-certificates
+      - git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+      - cd /tmp/bats-core
+      - git checkout v1.1.0
+      - ./install.sh /usr/local
+      - cd -
+      - export KUBECONFIG=/shared/kube/kubeconfig-121
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export EXTERNAL_DNS="$INSTANCE_IP.$DYNAMIC_DNS_SERVICE"
+      - bats -t katalog/tests/harbor/registry.sh
+      - bats -t katalog/tests/harbor/registry-notary.sh
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0-final-aws
+    pull: always
+    depends_on: [ e2e-vulns, e2e-chartmuseum, e2e-replication, e2e-registry ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-121
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
     when:
       status:
       - success
@@ -609,9 +831,9 @@ kind: pipeline
 name: release
 
 depends_on:
-  - e2e-kubernetes-1.16
-  - e2e-kubernetes-1.17
   - e2e-kubernetes-1.18
+  - e2e-kubernetes-1.19
+  - e2e-kubernetes-1.20
 
 platform:
   os: linux

--- a/README.md
+++ b/README.md
@@ -7,26 +7,28 @@ This repository contains all components necessary to deploy a container registry
 The following packages are included in the Fury Kubernetes Registry Katalog.
 
 - [harbor](katalog/harbor): Harbor is an open-source container image registry that secures images with role-based
-access control, scans images for vulnerabilities, and signs images as trusted. Version: **2.1.5**
+access control, scans images for vulnerabilities, and signs images as trusted. Version: **2.2.2**
 
 ## Requirements
 
 All packages in this repository have the following dependencies, for package
 specific dependencies, please visit the single package's documentation:
 
-- [Kubernetes](https://kubernetes.io) >= `v1.16.0`
+- [Kubernetes](https://kubernetes.io) >= `v1.18.0`
 - [Furyctl](https://github.com/sighupio/furyctl) package manager to download
   Fury packages >= [`v0.2.2`](https://github.com/sighupio/furyctl/releases/tag/v0.2.2)
-- [Kustomize](https://github.com/kubernetes-sigs/kustomize) >= `v3.3.0`
+- [Kustomize](https://github.com/kubernetes-sigs/kustomize) >= `v3.10.0`
 
 ## Compatibility
 
-| Module Version / Kubernetes Version |       1.14.X       |       1.15.X       |       1.16.X       |       1.17.X       |       1.18.X       |
-| ----------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
-| v1.0.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.0.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.1.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.1.1                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version |       1.14.X       |       1.15.X       |       1.16.X       |       1.17.X       |       1.18.X       |       1.19.X       |       1.20.X       |       1.21.X       |
+| ----------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| v1.0.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
+| v1.0.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
+| v1.1.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
+| v1.1.1                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
+| v1.1.2                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.2.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -8,7 +8,7 @@ Continue reading the Changelog to discover them:
 
 ## Changelog
 
-- Update Harbor from version `v2.1.5` to `v2.2.0`.
+- Update Harbor from version `v2.1.5` to `v2.2.2`.
 - Kubernetes support:
   - Deprecate Kubernetes 1.17 support.
   - Kubernetes 1.20 is considered stable.

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -1,0 +1,26 @@
+# Registry Module version 1.2.0
+
+SIGHUP team maintains this module updated and tested.
+That is the main reason why we worked on this new release. With the Kubernetes 1.21 release, it became the perfect time
+to start testing this module against this Kubernetes release.
+
+Continue reading the Changelog to discover them:
+
+## Changelog
+
+- Update Harbor from version `v2.1.5` to `v2.2.0`.
+- Kubernetes support:
+  - Deprecate Kubernetes 1.17 support.
+  - Kubernetes 1.20 is considered stable.
+  - Add tech-preview support to Kubernetes 1.21.
+
+## Upgrade path
+
+To upgrade this module from `v1.1.2` to `v1.2.0`, you need to download this new version, then apply the
+`kustomize` project. No further action is required.
+
+```bash
+$ kustomize build katalog/harbor/distributions/full-harbor-with-trivy | kubectl apply -f -
+# Or
+$ kustomize build katalog/harbor/distributions/full-harbor | kubectl apply -f -
+```

--- a/katalog/harbor/README.md
+++ b/katalog/harbor/README.md
@@ -12,19 +12,19 @@
 ## Image repository and tag
 
 * Harbor images from [dockerhub](https://hub.docker.com/u/goharbor):
-  * goharbor/chartmuseum-photon:v2.1.5
-  * goharbor/clair-photon:v2.1.5
-  * goharbor/clair-adapter-photon:v2.1.5
-  * goharbor/trivy-adapter-photon:v2.1.5
-  * goharbor/harbor-core:v2.1.5
-  * goharbor/harbor-db:v2.1.5
-  * goharbor/harbor-jobservice:v2.1.5
-  * goharbor/notary-server-photon:v2.1.5
-  * goharbor/notary-signer-photon:v2.1.5
-  * goharbor/harbor-portal:v2.1.5
-  * goharbor/redis-photon:v2.1.5
-  * goharbor/registry-photon:v2.1.5
-  * goharbor/harbor-registryctl:v2.1.5
+  * goharbor/chartmuseum-photon:v2.2.2
+  * goharbor/clair-photon:v2.2.2
+  * goharbor/clair-adapter-photon:v2.2.2
+  * goharbor/trivy-adapter-photon:v2.2.2
+  * goharbor/harbor-core:v2.2.2
+  * goharbor/harbor-db:v2.2.2
+  * goharbor/harbor-jobservice:v2.2.2
+  * goharbor/notary-server-photon:v2.2.2
+  * goharbor/notary-signer-photon:v2.2.2
+  * goharbor/harbor-portal:v2.2.2
+  * goharbor/redis-photon:v2.2.2
+  * goharbor/registry-photon:v2.2.2
+  * goharbor/harbor-registryctl:v2.2.2
 * Harbor repository: [https://github.com/goharbor/harbor](https://github.com/goharbor/harbor)
 
 ## Distributions

--- a/katalog/harbor/chartmuseum/kustomization.yaml
+++ b/katalog/harbor/chartmuseum/kustomization.yaml
@@ -9,7 +9,7 @@ kind: Kustomization
 images:
   - name: goharbor/chartmuseum-photon
     newName: registry.sighup.io/fury/goharbor/chartmuseum-photon
-    newTag: v2.1.5
+    newTag: v2.2.2
 
 resources:
   - pvc.yml

--- a/katalog/harbor/clair/kustomization.yaml
+++ b/katalog/harbor/clair/kustomization.yaml
@@ -13,10 +13,10 @@ resources:
 images:
   - name: goharbor/clair-photon
     newName: registry.sighup.io/fury/goharbor/clair-photon
-    newTag: v2.1.5
+    newTag: v2.2.2
   - name: goharbor/clair-adapter-photon
     newName: registry.sighup.io/fury/goharbor/clair-adapter-photon
-    newTag: v2.1.5
+    newTag: v2.2.2
 
 configMapGenerator:
   - name: clair

--- a/katalog/harbor/core/kustomization.yaml
+++ b/katalog/harbor/core/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 images:
   - name: goharbor/harbor-core
     newName: registry.sighup.io/fury/goharbor/harbor-core
-    newTag: v2.1.5
+    newTag: v2.2.2
 
 configMapGenerator:
   - name: core

--- a/katalog/harbor/database/kustomization.yaml
+++ b/katalog/harbor/database/kustomization.yaml
@@ -9,7 +9,7 @@ kind: Kustomization
 images:
   - name: goharbor/harbor-db
     newName: registry.sighup.io/fury/goharbor/harbor-db
-    newTag: v2.1.5
+    newTag: v2.2.2
   - name: busybox
     newName: registry.sighup.io/fury/busybox
     newTag: latest

--- a/katalog/harbor/jobservice/kustomization.yaml
+++ b/katalog/harbor/jobservice/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 images:
   - name: goharbor/harbor-jobservice
     newName: registry.sighup.io/fury/goharbor/harbor-jobservice
-    newTag: v2.1.5
+    newTag: v2.2.2
 
 configMapGenerator:
   - name: jobservice

--- a/katalog/harbor/notary/kustomization.yaml
+++ b/katalog/harbor/notary/kustomization.yaml
@@ -9,10 +9,10 @@ kind: Kustomization
 images:
   - name: goharbor/notary-server-photon
     newName: registry.sighup.io/fury/goharbor/notary-server-photon
-    newTag: v2.1.5
+    newTag: v2.2.2
   - name: goharbor/notary-signer-photon
     newName: registry.sighup.io/fury/goharbor/notary-signer-photon
-    newTag: v2.1.5
+    newTag: v2.2.2
 
 resources:
   - pki.yml

--- a/katalog/harbor/portal/kustomization.yaml
+++ b/katalog/harbor/portal/kustomization.yaml
@@ -9,7 +9,7 @@ kind: Kustomization
 images:
   - name: goharbor/harbor-portal
     newName: registry.sighup.io/fury/goharbor/harbor-portal
-    newTag: v2.1.5
+    newTag: v2.2.2
 
 resources:
   - deploy.yml

--- a/katalog/harbor/redis/kustomization.yaml
+++ b/katalog/harbor/redis/kustomization.yaml
@@ -9,7 +9,7 @@ kind: Kustomization
 images:
   - name: goharbor/redis-photon
     newName: registry.sighup.io/fury/goharbor/redis-photon
-    newTag: v2.1.5
+    newTag: v2.2.2
 
 resources:
   - sts.yml

--- a/katalog/harbor/registry/kustomization.yaml
+++ b/katalog/harbor/registry/kustomization.yaml
@@ -14,10 +14,10 @@ resources:
 images:
   - name: goharbor/registry-photon
     newName: registry.sighup.io/fury/goharbor/registry-photon
-    newTag: v2.1.5
+    newTag: v2.2.2
   - name: goharbor/harbor-registryctl
     newName: registry.sighup.io/fury/goharbor/harbor-registryctl
-    newTag: v2.1.5
+    newTag: v2.2.2
 
 configMapGenerator:
   - name: registry

--- a/katalog/harbor/trivy/kustomization.yaml
+++ b/katalog/harbor/trivy/kustomization.yaml
@@ -17,7 +17,7 @@ commonLabels:
 images:
   - name: goharbor/trivy-adapter-photon
     newName: registry.sighup.io/fury/goharbor/trivy-adapter-photon
-    newTag: v2.1.5
+    newTag: v2.2.2
 
 configMapGenerator:
   - name: trivy

--- a/katalog/tests/harbor/config/kind-config
+++ b/katalog/tests/harbor/config/kind-config
@@ -1,35 +1,38 @@
----
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 networking:
   apiServerAddress: "0.0.0.0"
   disableDefaultCNI: false
   podSubnet: 172.16.0.0/16
-  
-kubeadmConfigPatches:
-- |
-  kind: ClusterConfiguration
-  metadata:
-    name: config
-  etcd:
-    local:
-      extraArgs:
-        "listen-metrics-urls": "http://0.0.0.0:2378"
-  apiServer:
-    extraArgs:
-      "enable-admission-plugins": "NamespaceLifecycle,LimitRanger,PodNodeSelector,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
-
-kubeadmConfigPatchesJson6902:
-- group: kubeadm.k8s.io
-  version: v1beta2
-  kind: ClusterConfiguration
-  patch: |
-    - op: add
-      path: /apiServer/certSANs/-
-      value: docker
 
 nodes:
 - role: control-plane
+  kubeadmConfigPatches:
+  - |
+    group: kubeadm.k8s.io
+    version: v1beta1
+    kind: ClusterConfiguration
+    patch: |
+      - op: add
+        path: /apiServer/certSANs/-
+        value: docker
+  - |
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    etcd:
+      local:
+        extraArgs:
+          "listen-metrics-urls": "http://0.0.0.0:2378"
+    apiServer:
+      extraArgs:
+        "enable-admission-plugins": "NamespaceLifecycle,LimitRanger,PodNodeSelector,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+    controllerManager:
+      extraArgs:
+        "bind-address": "0.0.0.0"
+    scheduler:
+      extraArgs:
+        "bind-address": "0.0.0.0"
 
 - role: worker
   extraPortMappings:
@@ -37,3 +40,12 @@ nodes:
     hostPort: 80
   - containerPort: 31443 # nginx ingress controller https
     hostPort: 443
+
+containerdConfigPatches:
+- |-
+    [debug]
+      level = "debug"
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://mirror.gcr.io", "https://registry-1.docker.io"]


### PR DESCRIPTION
# Registry Module version 1.2.0

SIGHUP team maintains this module updated and tested.
That is the main reason why we worked on this new release. With the Kubernetes 1.21 release, it became the perfect time
to start testing this module against this Kubernetes release.

Continue reading the Changelog to discover them:

## Changelog

- Update Harbor from version `v2.1.5` to `v2.2.0`.
- Kubernetes support:
  - Deprecate Kubernetes 1.17 support.
  - Kubernetes 1.20 is considered stable.
  - Add tech-preview support to Kubernetes 1.21.

## Upgrade path

To upgrade this module from `v1.1.2` to `v1.2.0`, you need to download this new version, then apply the
`kustomize` project. No further action is required.

```bash
$ kustomize build katalog/harbor/distributions/full-harbor-with-trivy | kubectl apply -f -
# Or
$ kustomize build katalog/harbor/distributions/full-harbor | kubectl apply -f -
```
