### PR TITLE
chore(trivy): updated database offline download

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ All packages in this repository have the following dependencies, for package spe
 ```yaml
 bases:
   - name: registry/harbor
-    version: "v3.0.0"
+    version: "v3.0.1"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -10,6 +10,7 @@
 | v1.2.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
 | v2.0.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | v3.0.0                              |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v3.0.1                              |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues
@@ -25,4 +26,4 @@ There's no supported upgrade path. See [release note v2.0.0](releases/v2.0.0.md)
 
 ## Warning while upgrading from 2.x to 3.0
 
-There's no supported upgrade path. See [release note v3.0.0](releases/v3.0.0.md) for more information.
+There's no supported upgrade path. See [release note v3.0.1](releases/v3.0.1.md) for more information.

--- a/docs/releases/v3.0.1.md
+++ b/docs/releases/v3.0.1.md
@@ -1,0 +1,10 @@
+# Registry Module version 3.0.1
+
+## Changelog
+- The trivy configuration has been updated to download the new image with the updated vulnerability database every night. To do this we have added: [an image that is built every night](https://github.com/sighupio/trivy-adapter-photon-offline), an ad-hoc rbac and a cronjob to restart the pod. The new image is downloaded from the following [repository](https://quay.io/repository/sighup/trivy-adapter-photon-offline?tab=tags).
+
+## Upgrade path
+
+There's no supported upgrade path for this module from `v3.0.0` to `v3.0.1`.
+
+The recommended approach is a lift and shift migration. Start by copying over all the images from the old instance to the new one using Harbor's native replication and then sync the users and permissions.

--- a/docs/releases/v3.0.1.md
+++ b/docs/releases/v3.0.1.md
@@ -5,6 +5,4 @@
 
 ## Upgrade path
 
-There's no supported upgrade path for this module from `v3.0.0` to `v3.0.1`.
-
-The recommended approach is a lift and shift migration. Start by copying over all the images from the old instance to the new one using Harbor's native replication and then sync the users and permissions.
+To upgrade this module from `v3.0.0` to `v3.0.1`, you need to download this new version, then apply the `kustomize` project. No further action is required.

--- a/katalog/harbor/MAINTENANCE.md
+++ b/katalog/harbor/MAINTENANCE.md
@@ -52,3 +52,7 @@ To export the list of alerts from the YAML file to include them in the readme yo
 ```bash
 yq e '.spec.groups[] | .rules[] |  "| " + .alert + " | " + (.annotations.summary // "-" | sub("\n",". "))+ " | " + (.annotations.description // "-" | sub("\n",". ")) + " |"' katalog/harbor/exporter/rules.yml
 ```
+
+### Trivy Database Update Offline
+
+The trivy configuration has been updated to download the new image with the updated vulnerability database every night. To do this we have added: [an image that is built every night](https://github.com/sighupio/trivy-adapter-photon-offline), an ad-hoc rbac and a cronjob to restart the pod. The new image is downloaded from the following [repository](https://quay.io/repository/sighup/trivy-adapter-photon-offline?tab=tags).

--- a/katalog/harbor/trivy/cronjob.yml
+++ b/katalog/harbor/trivy/cronjob.yml
@@ -9,7 +9,7 @@ metadata:
   name: update-trivy-db-cronjob
 spec:
   concurrencyPolicy: Forbid
-  schedule: '0 2 * * *'
+  schedule: '0 4 * * *'
   jobTemplate:
     spec:
       backoffLimit: 2 

--- a/katalog/harbor/trivy/kustomization.yaml
+++ b/katalog/harbor/trivy/kustomization.yaml
@@ -19,7 +19,7 @@ commonLabels:
 
 images:
   - name: goharbor/trivy-adapter-photon
-    newName: quay.io/sighup/trivy-adapter-photon-offline
+    newName: registry.sighup.io/fury/goharbor/trivy-adapter-photon-offline
     newTag: v2.7.0
 
   - name: registry.sighup.io/fury/kubectl

--- a/katalog/harbor/trivy/kustomization.yaml
+++ b/katalog/harbor/trivy/kustomization.yaml
@@ -19,7 +19,7 @@ commonLabels:
 
 images:
   - name: goharbor/trivy-adapter-photon
-    newName: registry.sighup.io/fury/goharbor/trivy-adapter-photon
+    newName: quay.io/sighup/trivy-adapter-photon-offline
     newTag: v2.7.0
 
   - name: registry.sighup.io/fury/kubectl

--- a/katalog/harbor/trivy/sts.yml
+++ b/katalog/harbor/trivy/sts.yml
@@ -17,22 +17,6 @@ spec:
         runAsUser: 10000
         fsGroup: 10000
       automountServiceAccountToken: false
-      initContainers:
-        - name: "update-trivy-db"
-          image: goharbor/trivy-adapter-photon
-          imagePullPolicy: Always
-          command: ["/bin/sh"]
-          args: ["-c", "trivy image --download-db-only"]
-          volumeMounts:
-            - name: data
-              mountPath: /home/scanner/.cache
-              subPath:
-              readOnly: false
-          envFrom:
-            - configMapRef:
-                name: trivy
-            - secretRef:
-                name: trivy
       containers:
         - name: trivy
           image: goharbor/trivy-adapter-photon
@@ -48,11 +32,6 @@ spec:
           ports:
             - name: api-server
               containerPort: 8080
-          volumeMounts:
-          - name: data
-            mountPath: /home/scanner/.cache
-            subPath:
-            readOnly: false
           livenessProbe:
             httpGet:
               scheme: HTTP
@@ -78,6 +57,3 @@ spec:
             requests:
               cpu: 200m
               memory: 512Mi
-      volumes:
-      - name: data
-        emptyDir: {}


### PR DESCRIPTION
We've updated the way Trivy updates the vulnerability database. The new logic involves downloading the already updated image every night, and no longer using an init container.