### PR TITLE
chore(docs): add v3.5.1 release notes and adjust compatibility matrix

### DIFF
--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -6,8 +6,9 @@
 | ----------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
 | v3.2.0                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |
 | v3.3.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
-| v3.4.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v3.5.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v3.4.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
+| v3.5.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
+| v3.5.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/docs/releases/v3.5.1.md
+++ b/docs/releases/v3.5.1.md
@@ -1,14 +1,16 @@
-# Registry Add-On Release 3.4.0
+# Registry Add-On Release 3.5.1
 
 ## Changelog
 
-- Added compatibility with Kubernetes versions 1.33.x.
-- Added a new distribution named `harbor-ha`, where Redis, Postgres and storage are external. You can find out how to use it in the [examples](../../examples/harbor-ha/)
-- :warning: Updated Harbor to version 2.11.2. Please check the [Upgrade path section](#upgrade-path).
+- Updated CI to add Kubernetes v1.34.x support and drop Kubernetes v1.29.x support.
 
 > [!WARNING]
 >
 > If you are upgrading from a version <= v3.2.0, read the release notes for [v3.3.0](https://github.com/sighupio/add-on-registry/releases/tag/v3.3.0).
+<!-- space -->
+> [!NOTE]
+>
+> If you are running v3.5.0, this update does not add anything new. This is only a patch release to update the CI.
 
 ## Upgrade path
 


### PR DESCRIPTION
### Summary 💡

This PR adds a release note for the v3.5.1 version of the addon, which will be tagged after merging this branch.

### Description 📝

This release does not add anything new to the module itself. It's needed only to update our CI, to add support to Kubernetes v1.34.x and drop 1.29.x.

### Breaking Changes 💔

None

### Tests performed 🧪

N/A