### PR TITLE
fix: SBOM generation

### DIFF
--- a/katalog/harbor/core/kustomization.yaml
+++ b/katalog/harbor/core/kustomization.yaml
@@ -30,7 +30,7 @@ configMapGenerator:
       - POSTGRESQL_MAX_IDLE_CONNS=100
       - POSTGRESQL_MAX_OPEN_CONNS=900
       - EXT_ENDPOINT=https://core.harbor.domain
-      - CORE_URL=http://core
+      - CORE_URL=http://core:80
       - JOBSERVICE_URL=http://jobservice
       - REGISTRY_URL=http://registry:5000
       - TOKEN_SERVICE_URL=http://core/service/token

--- a/katalog/harbor/jobservice/kustomization.yaml
+++ b/katalog/harbor/jobservice/kustomization.yaml
@@ -21,7 +21,7 @@ configMapGenerator:
     files:
       - config.yml=config/config.yml
     literals:
-      - CORE_URL=http://core
+      - CORE_URL=http://core:80
       - REGISTRY_URL=http://registry:5000
       - TOKEN_SERVICE_URL=http://core/service/token
       - REGISTRY_CONTROLLER_URL=http://registry:8080


### PR DESCRIPTION

### Summary 💡

SBOM generation doesn't work properly in Harbor deployed via add-on. 

### Description 📝

Currently the CORE_URL env var is set to http://core, which correctly uses the Kubernetes Service inside the "registry" Namespace to comunicate directly to  the core Harbor component. 

But when a SBOM generation is requested, let's say for the image project1/repo1, when trivy has succesfully generated the SBOM file, jobservice tries to upload the file to core/project1/repo1, which is treated as a whole repo path, implicitly trying to push to the docker.io registry. 

This PR changes the CORE_URL env var to http://core:80. This way, the SBOM file will be uploaded to core:80/project1/repo1 which allows to properly distinguish the registry endpoint from the repository path. 

### Breaking Changes 💔

None

### Tests performed 🧪

- [ ] Tested SBOM generation in full setup
- [ ] Tested SBOM generation in HA setup

